### PR TITLE
feat(presets): Add replacement for rome to biome

### DIFF
--- a/lib/config/presets/internal/replacements.ts
+++ b/lib/config/presets/internal/replacements.ts
@@ -29,6 +29,7 @@ export const presets: Record<string, Preset> = {
       'replacements:renovate-pep440-to-renovatebot-pep440',
       'replacements:rollup-babel-to-scoped',
       'replacements:rollup-node-resolve-to-scoped',
+      'replacements:rome-to-biome',
       'replacements:vso-task-lib-to-azure-pipelines-task-lib',
       'replacements:vsts-task-lib-to-azure-pipelines-task-lib',
       'replacements:xmldom-to-scoped',
@@ -686,6 +687,17 @@ export const presets: Record<string, Preset> = {
         matchPackageNames: ['rollup-plugin-node-resolve'],
         replacementName: '@rollup/plugin-node-resolve',
         replacementVersion: '6.0.0',
+      },
+    ],
+  },
+  'rome-to-biome': {
+    description: 'The rome project has been discontinued and biome was announced.',
+    packageRules: [
+      {
+        matchDatasources: ['npm'],
+        matchPackageNames: ['rome'],
+        replacementName: '@biomejs/biome',
+        replacementVersion: '1.0.0',
       },
     ],
   },


### PR DESCRIPTION
## Changes

Adds replacement preset for rome to biome migration.

## Context

The Rome project (https://github.com/rome/tools) has been discontinued, and Biome was announced as an official fork (https://biomejs.dev/blog/annoucing-biome/). This preset provides the replacement for the migration.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
